### PR TITLE
Freez the encoder parameters after loading the last checkpoint/pre-trained model checkpoint and add a log.

### DIFF
--- a/fairseq/trainer.py
+++ b/fairseq/trainer.py
@@ -475,6 +475,12 @@ class Trainer(object):
                 self.model.load_state_dict(
                     state["model"], strict=True, model_cfg=self.cfg.model
                 )
+
+                # Freeze encoder parameters of the model loaded from checkpoints
+                for param in self.model.encoder.parameters():
+                    param.requires_grad = False
+                    logger.info("Encoder parameters froze!")
+
                 # save memory for later steps
                 del state["model"]
                 if utils.has_parameters(self.get_criterion()):


### PR DESCRIPTION

Freez the encoder parameters after loading the last checkpoint/pre-trained model checkpoint and add a log.